### PR TITLE
Add support for local language models, and multiple evaluation files

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,23 @@ pip install -r requirements.txt
 python scribendi.py --src <source file> --pred <prediction file>
 ```
 
+Note that multiple source and prediction files can be given, separated by
+colons. If the colon-separated lists of files are of identical length, they
+are matched directly. Alternatively, a single source file may be given along
+with multiple prediction files, for instance from multiple systems.
+Example:
+
+```bash
+python scribendi.py --src test.original --pred test.system1:test.system2
+```
+
+This is useful to save time with large language models and multiple small
+evaluation files.
+
 - Other options
 
 `--no_cuda`   
-`--model_id <str>`: Specify the id of GPT-2 related model of huggingface. (default: 'gpt2')  
+`--model_id <str>`: Specify the id of GPT-2 related model of huggingface. (default: 'gpt2') You can also specify a local directory, from which the model will be loaded.
 `--threshold <float>`: The threshold of a token sort ratio and a levenshtein distance ratio. (default: 0.8)  
 `--batch_size <int>`: The batch size to compute perplexity of a GPT-2 model faster. (default: 32)  
 `--example`: Show the perplexity, the token sort ration and the levenshtein distance ratio using the examples of Table 1 in the [paper](https://aclanthology.org/2021.emnlp-main.239/).

--- a/scribendi.py
+++ b/scribendi.py
@@ -1,3 +1,4 @@
+import os.path
 from transformers import GPT2TokenizerFast, GPT2LMHeadModel
 from fuzzywuzzy.fuzz import token_sort_ratio
 import torch
@@ -99,8 +100,11 @@ class ScribendiScore:
     def load_model(self, 
         model_id: str
     ) -> Tuple[GPT2TokenizerFast, GPT2LMHeadModel]:
-        tokenizer = GPT2TokenizerFast.from_pretrained(model_id)
-        model = GPT2LMHeadModel.from_pretrained(model_id)
+        local=os.path.exists(model_id)
+        tokenizer = GPT2TokenizerFast.from_pretrained(model_id,
+                local_files_only=local)
+        model = GPT2LMHeadModel.from_pretrained(model_id,
+                local_files_only=local)
         tokenizer.pad_token = tokenizer.eos_token
         if not self.no_cuda:
             model.to('cuda')

--- a/scribendi.py
+++ b/scribendi.py
@@ -168,10 +168,17 @@ def main(args):
             threshold=args.threshold,
             no_cuda=args.no_cuda
         )
-        src_sents = load_file(args.src)
-        pred_sents = load_file(args.pred)
-        print(scorer.score(src_sents, pred_sents,
-                            batch_size=args.batch_size))
+        src_files = args.src.split(':')
+        pred_files = args.pred.split(':')
+        if len(src_files) == 1 and len(pred_files) > 1:
+            src_files = src_files * len(pred_files)
+        assert len(src_files) == len(pred_files)
+        for src_file, pred_file in zip(src_files, pred_files):
+            src_sents = load_file(src_file)
+            pred_sents = load_file(pred_file)
+            print(src_file, pred_file)
+            print(scorer.score(src_sents, pred_sents,
+                                batch_size=args.batch_size))
     
 
 def get_parser():


### PR DESCRIPTION
The `--src` and `--pred` arguments now take colon-separated lists of files, so the model only has to be loaded once. The `--model_id` now also accepts a directory name, to allow loading local models (not just from Huggingface).

Thanks for a useful tool, I have been testing it on Swedish data with a Swedish GPT-2 model and everything works as expected.